### PR TITLE
Fix arm support ?

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -18,7 +18,7 @@ code = "https://github.com/knadh/listmonk"
 
 [integration]
 yunohost = ">= 11.1.15"
-architectures = ["amd64"]
+architectures = ["amd64", "armhf"]
 multi_instance = true
 ldap = false
 sso = false
@@ -46,13 +46,13 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://github.com/knadh/listmonk/releases/download/v2.4.0/listmonk_2.4.0_linux_amd64.tar.gz"
-        sha256 = "acdfd0f4549c15e3cd77a28778ac9904cc54abf3bec98074ee96edc64242971b"
+        amd64.url = "https://github.com/knadh/listmonk/releases/download/v2.4.0/listmonk_2.4.0_linux_amd64.tar.gz"
+        amd64.sha256 = "acdfd0f4549c15e3cd77a28778ac9904cc54abf3bec98074ee96edc64242971b"
+        armhf.url = "https://github.com/knadh/listmonk/archive/refs/tags/v2.4.0.tar.gz"
+        armhf.sha256 = "0a1fb22b485369fd47e8f19830e41c4fe5f6cf839f701fac0f6500071968faf8"
+        arm64.url = "https://github.com/knadh/listmonk/archive/refs/tags/v2.4.0.tar.gz"
+        arm64.sha256 = "0a1fb22b485369fd47e8f19830e41c4fe5f6cf839f701fac0f6500071968faf8"
         in_subdir = false
-
-        [resources.sources.arm]
-        url = "https://github.com/knadh/listmonk/archive/refs/tags/v2.4.0.tar.gz"
-        sha256 = "0a1fb22b485369fd47e8f19830e41c4fe5f6cf839f701fac0f6500071968faf8"
 
     [resources.system_user]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -18,7 +18,7 @@ code = "https://github.com/knadh/listmonk"
 
 [integration]
 yunohost = ">= 11.1.15"
-architectures = ["amd64", "armhf"]
+architectures = ["amd64", "armhf", "arm64"]
 multi_instance = true
 ldap = false
 sso = false

--- a/scripts/install
+++ b/scripts/install
@@ -44,7 +44,7 @@ ynh_script_progression --message="Setting up source files..." --weight=3
 # Download, check integrity, uncompress and patch the source from app.src
 if [ $YNH_ARCH == "armhf" ] || [ $YNH_ARCH == "arm64" ]
 then
-	ynh_setup_source --dest_dir="$install_dir/build" --source_id=arm
+	ynh_setup_source --dest_dir="$install_dir/build"
 	pushd "$install_dir/build"
 		# Build the sources
 		ynh_use_go

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -36,7 +36,7 @@ then
 	# Download, check integrity, uncompress and patch the source from app.src
 	if [ $YNH_ARCH == "armhf" ] || [ $YNH_ARCH == "arm64" ]
 	then
-		ynh_setup_source --dest_dir="$install_dir/build" --source_id=arm --keep="$install_dir/config.toml"
+		ynh_setup_source --dest_dir="$install_dir/build" --keep="$install_dir/config.toml"
 		# Install Nodejs
 		ynh_exec_warn_less ynh_install_nodejs --nodejs_version=$nodejs_version
 		# Install Go


### PR DESCRIPTION

cf https://github.com/YunoHost-Apps/listmonk_ynh/commit/c4e66613952df8d125c878659ee0c8d5876b9b05 ... I'm confused because the list of supported arch still doesnt include armhf / arm64

And also with the current syntax for sources, yunohost will prefetch the source for ARM even when running on amd64