### PR TITLE
Fix build of listmonk executable on arm64 and armhf

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -46,13 +46,15 @@ if [ $YNH_ARCH == "armhf" ] || [ $YNH_ARCH == "arm64" ]
 then
 	ynh_setup_source --dest_dir="$install_dir/build"
 	pushd "$install_dir/build"
+		# Change to sources directory
+		cd listmonk-*
 		# Build the sources
 		ynh_use_go
 		export GOPATH="$install_dir/build/go"
 		export GOCACHE="$install_dir/build/.cache"
 		ynh_use_nodejs
 		make dist
-		mv listmonk ..
+		mv listmonk ../../
 	popd
 	ynh_remove_go
 	ynh_remove_nodejs


### PR DESCRIPTION
## Problem

Installing `listmonk` on ARM systems results in an error #30 

## Solution

By changing in to the directory containing the listmonk source before attempting to build the executable when running on ARM based systems.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
