### PR TITLE
Enable allow_email and add a post install doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Listmonk is a standalone, self-hosted, newsletter and mailing list manager. It i
 * Official app website: <https://listmonk.app/>
 * Official admin documentation: <https://listmonk.app/docs/>
 * Upstream app code repository: <https://github.com/knadh/listmonk>
-* YunoHost documentation for this app: <https://yunohost.org/app_listmonk>
 * Report a bug: <https://github.com/YunoHost-Apps/listmonk_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -32,7 +32,6 @@ Listmonk est un gestionnaire de newsletter et de liste de diffusion autonome et 
 * Site officiel de l’app : <https://listmonk.app/>
 * Documentation officielle de l’admin : <https://listmonk.app/docs/>
 * Dépôt de code officiel de l’app : <https://github.com/knadh/listmonk>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_listmonk>
 * Signaler un bug : <https://github.com/YunoHost-Apps/listmonk_ynh/issues>
 
 ## Informations pour les développeurs

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,0 +1,16 @@
+You have to configure SMTP from the web interface at https://__DOMAIN__/admin
+
+Visit Settings -> General and replace these values:
+
+- Root URL: https://__DOMAIN__
+- Default from email: listmonk <__APP__@__DOMAIN__>
+
+Visit Settings -> SMTP and replace with these values:
+
+- Host: 127.0.0.1
+- Port: 25
+- Auth protocol: PLAIN
+- User: __APP__
+- Password: __MAIL_PWD__
+
+Then, test the connection

--- a/manifest.toml
+++ b/manifest.toml
@@ -34,9 +34,6 @@ ram.runtime = "50M"
     type = "group"
     default = "visitors"
 
-    [install.admin]
-    type = "user"
-
 [resources]
 
     [resources.sources]
@@ -50,7 +47,13 @@ ram.runtime = "50M"
         arm64.sha256 = "832c5a34ed78446c179ed5423cdbce51d3e51333c1ea6cf11c74b63e0776193a"
         in_subdir = false
 
+        autoupdate.strategy = "latest_github_release"
+        autoupdate.asset.amd64 = ".*_linux_amd64.tar.gz"
+        autoupdate.asset.armhf = ".*_linux_armv7.tar.gz"
+        autoupdate.asset.arm64 = ".*_linux_arm64.tar.gz"
+
     [resources.system_user]
+    allow_email = true
 
     [resources.ports]
 
@@ -65,10 +68,11 @@ ram.runtime = "50M"
     admin.auth_header = false
     admin.allowed = "admins"
 
+    # internal API, should not be allowed to visitors
     api.url = "/api"
     api.show_tile = false
     api.auth_header = false
-    api.allowed = "visitors"
+    api.allowed = "admins"
 
     [resources.apt]
     packages = "postgresql"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,6 +8,29 @@
 # PERSONAL HELPERS
 #=================================================
 
+# FIXME https://listmonk.app/docs/swagger/#/Settings/getSettings
+_listmonk_configure_with_api () {
+    python -c """
+from urllib.request import urlopen, Request
+with urlopen('http://localhost:$port/api/settings') as url:
+    data = json.load(url)
+
+data['data']['app.root_url'] = "https://$domain"
+data['data']['app.from_email'] = "listmonk <noreply@$domain>"
+data['data']['smtp'][0]['host'] = "127.0.0.1"
+data['data']['smtp'][0]['auth_protocol'] = "plain"
+data['data']['smtp'][0]['username'] = "$app"
+data['data']['smtp'][0]['password'] = "$mail_pwd"
+
+data_bytes = bytes(json.dumps(data), encoding='utf8')
+
+request = Request('http://localhost:$port/api/settings', method='PUT', data=data_bytes, headers={'Content-Type': 'application/json'})
+
+with urlopen(request) as response:
+    print(response.read())
+"""
+}
+
 #=================================================
 # EXPERIMENTAL HELPERS
 #=================================================

--- a/tests.toml
+++ b/tests.toml
@@ -7,3 +7,5 @@ test_format = 1.0
     # -------------------------------
 
     test_upgrade_from.4b1297d8.name = "Upgrade from  2.3.0"
+    test_upgrade_from.4b1297d8.args.admin = "package_checker"
+    test_upgrade_from.4b1297d8.args.password = "much_s3cur1ty"

--- a/tests.toml
+++ b/tests.toml
@@ -7,5 +7,6 @@ test_format = 1.0
     # -------------------------------
 
     test_upgrade_from.4b1297d8.name = "Upgrade from  2.3.0"
-    test_upgrade_from.4b1297d8.args.admin = "package_checker"
+    test_upgrade_from.4b1297d8.args.admin    = "package_checker"
     test_upgrade_from.4b1297d8.args.password = "much_s3cur1ty"
+    test_upgrade_from.4b1297d8.args.domain   = "domain.tld"


### PR DESCRIPTION
## Problem

- The app can't send emails

## Solution

- Use `allow_email` in the manifest
- Add post install instructions

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
